### PR TITLE
Add rubocop file and fix broken cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Style/HashSyntax:
   EnforcedStyle: no_mixed_keys
 
 Style/NumericLiterals:
-  Strict: false
+  MinDigits: 12
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,15 @@
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
 
 Metrics/LineLength:
   Max: 120
+
+Style/Documentation:
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,24 @@
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/LineLength:
+  Max: 120
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: never
+
+Style/HashSyntax:
+  EnforcedStyle: no_mixed_keys
+
+Style/NumericLiterals:
+  Strict: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma 
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.1
   - 2.6.3
+  - 2.6.1
 before_install: gem install bundler -v 2.0.2
 
 matrix:
   include:
-  - rvm: ruby-head
-    script: bundle exec rubocop
+  - script: bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ rvm:
   - 2.6.1
 before_install: gem install bundler -v 2.0.2
 
-script:
-  - bundle exec rubocop -c build/rubocop-config/.rubocop.yml
+jobs:
+  include:
+    - stage: test
+      script: bundle exec rspec
+    - stage: rubocop
+      scrip: bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ rvm:
   - 2.6.1
 before_install: gem install bundler -v 2.0.2
 
-jobs:
-  include:
-    - stage: test
-      script: bundle exec rspec
-    - stage: rubocop
-      scrip: bundle exec rubocop
+script:
+  - bundle exec rspec
+  - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ cache: bundler
 rvm:
   - 2.6.1
 before_install: gem install bundler -v 2.0.2
+
+script:
+  - bundle exec rubocop -c build/rubocop-config/.rubocop.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.1
+  - 2.6.3
 before_install: gem install bundler -v 2.0.2
 
-script:
-  - bundle exec rspec
-  - bundle exec rubocop
+matrix:
+  include:
+  - rvm: ruby-head
+    script: bundle exec rubocop

--- a/lib/nhl_stats.rb
+++ b/lib/nhl_stats.rb
@@ -6,7 +6,7 @@ require "nhl_stats/team"
 require "faraday"
 require "json"
 
-API_ROOT = "https://statsapi.web.nhl.com/api/v1"
+API_ROOT = "https://statsapi.web.nhl.com/api/v1".freeze
 
 module NHLStats
   class Error < StandardError; end

--- a/lib/nhl_stats/game.rb
+++ b/lib/nhl_stats/game.rb
@@ -24,7 +24,7 @@ module NHLStats
     def self.find(id)
       response = Faraday.get("#{API_ROOT}/game/#{id}/linescore")
       attributes = JSON.parse(response.body)
-      new(attributes.merge({:id => id}))
+      new(attributes.merge(:id => id))
     end
 
     def self.list(params = {})

--- a/lib/nhl_stats/game.rb
+++ b/lib/nhl_stats/game.rb
@@ -4,12 +4,8 @@ module NHLStats
 
     def initialize(game_data)
       @id = game_data[:id] || game_data.dig("gamePk")
-      home = game_data.dig("teams", "home")
-      away = game_data.dig("teams", "away")
-      @home_team_id = home.dig("team", "id")
-      @away_team_id = away.dig("team", "id")
-      @home_score = home.dig("goals") || home.dig("score")
-      @away_score = away.dig("goals") || away.dig("score")
+      home_team_data(game_data)
+      away_team_data(game_data)
       @date = Time.parse(game_data.dig("periods", 0, "startTime") || game_data.dig("gameDate"))
     end
 
@@ -33,6 +29,20 @@ module NHLStats
         fetch("dates", []).
         map { |d| d.fetch("games", []).map { |g| NHLStats::Game.new(g) } }.
         flatten
+    end
+
+    private
+
+    def home_team_data(game_data)
+      home = game_data.dig("teams", "home")
+      @home_team_id = home.dig("team", "id")
+      @home_score = home.dig("goals") || home.dig("score")
+    end
+
+    def away_team_data(game_data)
+      away = game_data.dig("teams", "away")
+      @away_team_id = away.dig("team", "id")
+      @away_score = away.dig("goals") || away.dig("score")
     end
   end
 end

--- a/lib/nhl_stats/player.rb
+++ b/lib/nhl_stats/player.rb
@@ -11,11 +11,7 @@ module NHLStats
 
       # Roster response returns an array of players w/o the following
       if player_data.key?("firstName")
-        @first_name = player_data["firstName"]
-        @last_name = player_data["lastName"]
-        @birth_date = Date.parse(player_data["birthDate"])
-        @nationality = player_data["nationality"]
-        @active = player_data["active"]
+        roster_response_data(player_data)
       else
         @active = true
       end
@@ -25,6 +21,16 @@ module NHLStats
       response = Faraday.get("#{API_ROOT}/people/#{id}")
       attributes = JSON.parse(response.body).dig("people", 0)
       new(attributes)
+    end
+
+    private
+
+    def roster_response_data(player_data)
+      @first_name = player_data["firstName"]
+      @last_name = player_data["lastName"]
+      @birth_date = Date.parse(player_data["birthDate"])
+      @nationality = player_data["nationality"]
+      @active = player_data["active"]
     end
   end
 end

--- a/lib/nhl_stats/version.rb
+++ b/lib/nhl_stats/version.rb
@@ -1,3 +1,3 @@
 module NHLStats
-  VERSION = "0.1.0"
+  VERSION = "0.1.0".freeze
 end

--- a/spec/player/player_spec.rb
+++ b/spec/player/player_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe NHLStats::Player do
     end
 
     [
-      {:field => :id, :value => 8479314},
-      {:field => :full_name, :value => "Matthew Tkachuk"},
-      {:field => :first_name, :value => "Matthew"},
-      {:field => :last_name, :value => "Tkachuk"},
-      {:field => :number, :value => 19},
-      {:field => :birth_date, :value => Date.new(1997, 12, 11)},
-      {:field => :nationality, :value => "USA"},
-      {:field => :active, :value => true},
-      {:field => :position, :value => "LW"},
+      { :field => :id, :value => 8_479_314 },
+      { :field => :full_name, :value => "Matthew Tkachuk" },
+      { :field => :first_name, :value => "Matthew" },
+      { :field => :last_name, :value => "Tkachuk" },
+      { :field => :number, :value => 19 },
+      { :field => :birth_date, :value => Date.new(1997, 12, 11) },
+      { :field => :nationality, :value => "USA" },
+      { :field => :active, :value => true },
+      { :field => :position, :value => "LW" },
     ].each do |hash|
       it "should return the correct value for #{hash[:field]}" do
         VCR.use_cassette("single_player") do

--- a/spec/player/player_spec.rb
+++ b/spec/player/player_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NHLStats::Player do
     end
 
     [
-      { :field => :id, :value => 8_479_314 },
+      { :field => :id, :value => 8479314 },
       { :field => :full_name, :value => "Matthew Tkachuk" },
       { :field => :first_name, :value => "Matthew" },
       { :field => :last_name, :value => "Tkachuk" },

--- a/spec/team/team_spec.rb
+++ b/spec/team/team_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NHLStats::Team do
     it "should return an array of Players" do
       VCR.use_cassette("team_roster") do
         players = NHLStats::Team.find(20).current_roster
-        expect(players).to all( be_instance_of(NHLStats::Player) )
+        expect(players).to all(be_instance_of(NHLStats::Player))
       end
     end
   end
@@ -21,9 +21,9 @@ RSpec.describe NHLStats::Team do
     end
 
     [
-      {:field => :id, :value => 20},
-      {:field => :name, :value => "Calgary Flames"},
-      {:field => :abbreviation, :value => "CGY"},
+      { :field => :id, :value => 20 },
+      { :field => :name, :value => "Calgary Flames" },
+      { :field => :abbreviation, :value => "CGY" },
     ].each do |hash|
       it "should return the correct value for #{hash[:field]}" do
         VCR.use_cassette("single_team") do
@@ -38,7 +38,7 @@ RSpec.describe NHLStats::Team do
     it "should return an array of teams" do
       VCR.use_cassette("list_teams") do
         teams = NHLStats::Team.list
-        expect(teams).to all( be_instance_of(NHLStats::Team) )
+        expect(teams).to all(be_instance_of(NHLStats::Team))
       end
     end
 


### PR DESCRIPTION
Adds rubocop file with specifications that are different from the default rule set.
Also modifies some code so that there are no rubocop warnings.
Finally, adds a rubocop check to the Travis CI builds, to ensure that the cops are respected.