### PR TITLE
Require 'time' in nhl_stats.rb

### DIFF
--- a/lib/nhl_stats.rb
+++ b/lib/nhl_stats.rb
@@ -5,6 +5,7 @@ require "nhl_stats/team"
 
 require "faraday"
 require "json"
+require "time"
 
 API_ROOT = "https://statsapi.web.nhl.com/api/v1".freeze
 


### PR DESCRIPTION
Allows the use of Time.parse without other dependencies, otherwise unavailable in the core Ruby [Time](https://ruby-doc.org/core-2.6.5/Time.html) class.