### PR TITLE
Add bounds for faraday and json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     nhl_stats (0.1.0)
-      faraday
-      json
+      faraday (~> 0.15.4)
+      json (~> 2.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/nhl_stats.gemspec
+++ b/nhl_stats.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday ~> 0.15.4"
-  spec.add_dependency "json ~> 2.2.0"
+  spec.add_dependency "faraday", "~> 0.15.4"
+  spec.add_dependency "json", "~> 2.2.0"
 end

--- a/nhl_stats.gemspec
+++ b/nhl_stats.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
-  spec.add_dependency "json"
+  spec.add_dependency "faraday ~> 0.15.4"
+  spec.add_dependency "json ~> 2.2.0"
 end


### PR DESCRIPTION
More housecleaning. Remove warning from `gem build` by bounding `faraday` and `json` requirements.