### PR TITLE
Remove 'allowed_push_host'

### DIFF
--- a/nhl_stats.gemspec
+++ b/nhl_stats.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://shrugguy.com"
   spec.license       = "MIT"
 
-  spec.metadata["allowed_push_host"] = "https://shrugguy.com"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://shrugguy.com"
   spec.metadata["changelog_uri"] = "https://shrugguy.com"


### PR DESCRIPTION
`allowed_push_host` is used to specify a private source for gems. shrugguy.com is not a valid source. DERP