### PR TITLE
Update rvm to test vs multiple versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.3
-  - 2.6.1
+  - 2.7
+  - 2.6
+  - 2.5
 before_install: gem install bundler -v 2.0.2
 
 matrix:


### PR DESCRIPTION
Previous config tested a few specific versions of ruby, this expands the config to trigger on three of the most recent minor Ruby versions (2.5, 2.6, 2.7).

#TODO: Later, add 3.0 to this