### PR TITLE
Add ability to get Team instance from player

### DIFF
--- a/lib/nhl_stats/player.rb
+++ b/lib/nhl_stats/player.rb
@@ -1,13 +1,14 @@
 module NHLStats
   class Player
     attr_reader :id, :full_name, :first_name, :last_name, :number, :birth_date,
-      :nationality, :active, :position
+      :nationality, :active, :position, :team_id
 
     def initialize(player_data)
       @id = player_data["id"]
       @full_name = player_data["fullName"]
       @number = (player_data["primaryNumber"] || player_data["jerseyNumber"]).to_i
       @position = player_data.dig("primaryPosition", "abbreviation") || player_data.dig("position", "abbreviation")
+      @team_id = player_data["currentTeam"]["id"]
 
       # Roster response returns an array of players w/o the following
       if player_data.key?("firstName")
@@ -21,6 +22,10 @@ module NHLStats
       response = Faraday.get("#{API_ROOT}/people/#{id}")
       attributes = JSON.parse(response.body).dig("people", 0)
       new(attributes)
+    end
+
+    def team
+      @team ||= Team.find(team_id)
     end
 
     private

--- a/lib/nhl_stats/team.rb
+++ b/lib/nhl_stats/team.rb
@@ -45,7 +45,9 @@ module NHLStats
 
     def roster_response_to_players(response)
       JSON.parse(response.body).fetch("roster", []).map do |p_data|
-        NHLStats::Player.new(p_data.delete("person").merge(p_data))
+        attributes = p_data.delete("person").merge(p_data)
+        attributes["currentTeam"] = { "id" => id }
+        NHLStats::Player.new(attributes)
       end
     end
 

--- a/spec/player/player_spec.rb
+++ b/spec/player/player_spec.rb
@@ -30,4 +30,16 @@ RSpec.describe NHLStats::Player do
       end
     end
   end
+
+  describe "#team" do
+    it "should return the team the player is on", :aggregate_failures do
+      VCR.use_cassettes([{name: "single_player"}, {name: "single_team"}]) do
+        player = NHLStats::Player.find(8479314)
+
+        expect(NHLStats::Team).to receive(:find).with(player.team_id).and_call_original
+        expect(player.team).to be_instance_of(NHLStats::Team)
+        expect(player.team.id).to eq player.team_id
+      end
+    end
+  end
 end

--- a/spec/player/player_spec.rb
+++ b/spec/player/player_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe NHLStats::Player do
 
   describe "#team" do
     it "should return the team the player is on", :aggregate_failures do
-      VCR.use_cassettes([{name: "single_player"}, {name: "single_team"}]) do
+      VCR.use_cassettes([{ name: "single_player" }, { name: "single_team" }]) do
         player = NHLStats::Player.find(8479314)
 
         expect(NHLStats::Team).to receive(:find).with(player.team_id).and_call_original


### PR DESCRIPTION
Minor change allowing you to access a `Team` instance via the `Player` instance. 

Example:
```ruby
player = NHLStats::Player.find(8477474)
player.team
#=> #<NHLStats::Team:0x00007fe9e9220260 @id=23, @name="Vancouver Canucks", @abbreviation="VAN">
```

Also updated `Team` to include it's id when creating a `Player` via the roster methods.